### PR TITLE
chore: replace ssh.NewClient sessions with standard ssh channels

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module slider
 
-go 1.21
+go 1.22
 
 require (
 	github.com/creack/pty v1.1.21

--- a/server/console.go
+++ b/server/console.go
@@ -172,7 +172,7 @@ func (s *server) cmdExecute(args ...string) {
 				s.console.Escape.Reset,
 			)
 		}
-		if _, _, err := session.sendRequestAndRetry(
+		if _, _, err := session.sendRequest(
 			"session-exec",
 			true,
 			[]byte(strings.Join(executeCmd.Args(), " ")),
@@ -231,7 +231,7 @@ func (s *server) cmdSessions(args ...string) {
 			_, _ = fmt.Printf("\r%s\n\n\r", sessErr)
 			return
 		}
-		if _, _, err = session.sendRequestAndRetry(
+		if _, _, err = session.sendRequest(
 			"session-shell",
 			true,
 			nil,
@@ -249,7 +249,7 @@ func (s *server) cmdSessions(args ...string) {
 			_, _ = fmt.Printf("\r%s\n\n\r", sessErr)
 			return
 		}
-		if _, _, err = session.sendRequestAndRetry(
+		if _, _, err = session.sendRequest(
 			"disconnect",
 			true,
 			nil,


### PR DESCRIPTION
- Removed the ssh.NewClient from the client that was used to create a session channel and use session pipes.
- With this change ssh connection requests and session requests no longer collide and is no need for retries on the server side.
- Quick fix to an issue when shel is zsh and terminal is not PTY.
- go1.22