### PR TITLE
chore: console should not use colors if no pty

### DIFF
--- a/server/conout.go
+++ b/server/conout.go
@@ -4,24 +4,49 @@ import (
 	"flag"
 	"fmt"
 	"slider/pkg/colors"
+	"slider/pkg/interpreter"
 	"strings"
 )
+
+var (
+	warnColor   = colors.Console.Warn
+	debugColor  = colors.Console.Debug
+	errorColor  = colors.Console.Error
+	okColor     = colors.Console.Ok
+	resetColor  = colors.Reset
+	systemColor = colors.Console.System
+)
+
+func setConsoleColors() {
+	if !interpreter.IsPtyOn() {
+		warnColor = []byte{}
+		debugColor = []byte{}
+		errorColor = []byte{}
+		okColor = []byte{}
+		systemColor = []byte{}
+		resetColor = []byte{}
+	}
+}
+
+func getPrompt() string {
+	return fmt.Sprintf("Slider%s>%s ", string(systemColor), string(resetColor))
+}
 
 func (c *Console) PrintlnWarn(m string, args ...interface{}) {
 	msg := fmt.Sprintf(m, args...)
 	c.Output.Printf(
 		"\r%s%s%s\r\n",
-		string(colors.Console.Warn),
+		string(warnColor),
 		msg,
-		string(colors.Reset),
+		string(resetColor),
 	)
 }
 
 func (c *Console) PrintWarnSelect(selected string, args ...string) {
 	msg := fmt.Sprintf("%s%s%s",
-		string(colors.Console.Warn),
+		string(warnColor),
 		selected,
-		string(colors.Reset))
+		string(resetColor))
 	c.Output.Printf("\r%s%s\r\n", msg, strings.Join(args, " "))
 }
 
@@ -29,8 +54,8 @@ func (c *Console) PrintlnDebugStep(m string, args ...interface{}) {
 	msg := fmt.Sprintf(m, args...)
 	c.Output.Printf(
 		"\r[%s*%s] %s\r\n",
-		string(colors.Console.Debug),
-		string(colors.Reset),
+		string(debugColor),
+		string(resetColor),
 		msg,
 	)
 }
@@ -39,8 +64,8 @@ func (c *Console) PrintlnErrorStep(m string, args ...interface{}) {
 	msg := fmt.Sprintf(m, args...)
 	c.Output.Printf(
 		"\r[%s-%s] %s\r\n",
-		string(colors.Console.Error),
-		string(colors.Reset),
+		string(errorColor),
+		string(resetColor),
 		msg,
 	)
 }
@@ -49,8 +74,8 @@ func (c *Console) PrintlnOkStep(m string, args ...interface{}) {
 	msg := fmt.Sprintf(m, args...)
 	c.Output.Printf(
 		"\r[%s+%s] %s\r\n",
-		string(colors.Console.Ok),
-		string(colors.Reset),
+		string(okColor),
+		string(resetColor),
 		msg,
 	)
 }

--- a/server/console.go
+++ b/server/console.go
@@ -30,6 +30,9 @@ type Console struct {
 func (s *server) NewConsole() string {
 	var out string
 
+	// Set Console Colors
+	setConsoleColors()
+
 	// Get available Commands
 	commands := s.initCommands()
 
@@ -75,12 +78,8 @@ func (s *server) NewConsole() string {
 		"\r\nPress CTRL^C again or Type \"bg\" to background the console," +
 			"\r\nType \"exit\" to terminate the server.\r\n",
 	)
-	s.console.Term.SetPrompt(
-		"\rSlider" +
-			string(colors.Console.System) +
-			" > " +
-			string(colors.Reset),
-	)
+
+	s.console.Term.SetPrompt(getPrompt())
 
 	for consoleInput := true; consoleInput; {
 		var fCmd string


### PR DESCRIPTION
Avoid using console colours if pty is not detected